### PR TITLE
Add settings page for preferences selection

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import { createMuiTheme, ThemeProvider } from "@material-ui/core/styles";
 import FavoritePage from "./containers/favoritePage/FavoritePage";
 import Playlist from "./containers/playlist";
 import PlaylistDetail from "./containers/playlist/PlaylistDetail";
+import Settings from "./containers/settings";
 
 const theme = createMuiTheme({
   typography: {
@@ -48,6 +49,9 @@ function App() {
             </Route>
             <Route exact path="/playlist/detail">
               <PlaylistDetail />
+            </Route>
+            <Route exact path="/settings">
+              <Settings />
             </Route>
             <Route exact path="/">
               <Home />

--- a/src/App.js
+++ b/src/App.js
@@ -6,31 +6,18 @@ import Catergory from "./containers/catergory";
 import Player from "./containers/player";
 import Layout from "./containers/layout";
 import Search from "./containers/search";
-import { createMuiTheme, ThemeProvider } from "@material-ui/core/styles";
 
 import FavoritePage from "./containers/favoritePage/FavoritePage";
 import Playlist from "./containers/playlist";
 import PlaylistDetail from "./containers/playlist/PlaylistDetail";
 import Settings from "./containers/settings";
-
-const theme = createMuiTheme({
-  typography: {
-    fontFamily: "Roboto, Arial",
-  },
-  palette: {
-    primary: {
-      main: "#179992",
-    },
-  },
-});
-
+import PreferencesProvider from "./contexts/PreferencesContext";
 
 function App() {
-
   return (
-    <ThemeProvider theme={theme}>
+    <PreferencesProvider>
       <Router>
-        <Layout>    
+        <Layout>
           <Switch>
             <Route path="/category/:category/:subCategoryOne?/:subCategoryTwo?/:subCategoryThree?">
               <Catergory />
@@ -59,7 +46,7 @@ function App() {
           </Switch>
         </Layout>
       </Router>
-    </ThemeProvider>
+    </PreferencesProvider>
   );
 }
 

--- a/src/containers/settings/Settings.js
+++ b/src/containers/settings/Settings.js
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Container, Typography, Paper, FormControl, FormLabel, RadioGroup, FormControlLabel, Radio, Divider } from "@material-ui/core";
+import { usePreferences } from "../../contexts/PreferencesContext";
 
 const colorSchemes = [
   { value: "sepia", label: "Sepia" },
@@ -17,31 +18,12 @@ const languages = [
   { value: "english", label: "English" },
 ];
 
-const preferenceStorageKey = "user_preferences";
-
-const readPreferences = () => {
-  const stored = localStorage.getItem(preferenceStorageKey);
-  if (!stored) return {};
-
-  try {
-    return JSON.parse(stored);
-  } catch (error) {
-    return {};
-  }
-};
-
-const writePreferences = (preferences) => {
-  localStorage.setItem(preferenceStorageKey, JSON.stringify(preferences));
-};
-
 const Settings = () => {
-  const storedPreferences = readPreferences();
-  const [colorScheme, setColorScheme] = useState(storedPreferences.colorScheme || "light");
-  const [language, setLanguage] = useState(storedPreferences.language || "english");
-
-  useEffect(() => {
-    writePreferences({ colorScheme, language });
-  }, [colorScheme, language]);
+  const {
+    preferences: { colorScheme, language },
+    setColorScheme,
+    setLanguage,
+  } = usePreferences();
 
   return (
     <Container maxWidth="md" style={{ paddingTop: 32, paddingBottom: 32 }}>

--- a/src/containers/settings/Settings.js
+++ b/src/containers/settings/Settings.js
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from "react";
+import { Container, Typography, Paper, FormControl, FormLabel, RadioGroup, FormControlLabel, Radio, Divider } from "@material-ui/core";
+
+const colorSchemes = [
+  { value: "sepia", label: "Sepia" },
+  { value: "red", label: "Red" },
+  { value: "green", label: "Green" },
+  { value: "blue", label: "Blue" },
+  { value: "dark", label: "Dark" },
+  { value: "light", label: "Light" },
+];
+
+const languages = [
+  { value: "french", label: "French" },
+  { value: "urdu", label: "Urdu" },
+  { value: "norsk", label: "Norsk" },
+  { value: "english", label: "English" },
+];
+
+const preferenceStorageKey = "user_preferences";
+
+const readPreferences = () => {
+  const stored = localStorage.getItem(preferenceStorageKey);
+  if (!stored) return {};
+
+  try {
+    return JSON.parse(stored);
+  } catch (error) {
+    return {};
+  }
+};
+
+const writePreferences = (preferences) => {
+  localStorage.setItem(preferenceStorageKey, JSON.stringify(preferences));
+};
+
+const Settings = () => {
+  const storedPreferences = readPreferences();
+  const [colorScheme, setColorScheme] = useState(storedPreferences.colorScheme || "light");
+  const [language, setLanguage] = useState(storedPreferences.language || "english");
+
+  useEffect(() => {
+    writePreferences({ colorScheme, language });
+  }, [colorScheme, language]);
+
+  return (
+    <Container maxWidth="md" style={{ paddingTop: 32, paddingBottom: 32 }}>
+      <Paper style={{ padding: 24 }}>
+        <Typography variant="h5" gutterBottom>
+          Preferences
+        </Typography>
+        <Typography variant="body1" color="textSecondary" paragraph>
+          Choose your preferred color scheme and language for the application.
+        </Typography>
+        <Divider style={{ marginBottom: 24 }} />
+
+        <FormControl component="fieldset" style={{ marginBottom: 24 }}>
+          <FormLabel component="legend">Color scheme</FormLabel>
+          <RadioGroup
+            aria-label="color-scheme"
+            name="color-scheme"
+            value={colorScheme}
+            onChange={(event) => setColorScheme(event.target.value)}
+          >
+            {colorSchemes.map((scheme) => (
+              <FormControlLabel key={scheme.value} value={scheme.value} control={<Radio color="primary" />} label={scheme.label} />
+            ))}
+          </RadioGroup>
+        </FormControl>
+
+        <Divider style={{ marginBottom: 24 }} />
+
+        <FormControl component="fieldset">
+          <FormLabel component="legend">Language</FormLabel>
+          <RadioGroup
+            aria-label="language"
+            name="language"
+            value={language}
+            onChange={(event) => setLanguage(event.target.value)}
+          >
+            {languages.map((option) => (
+              <FormControlLabel key={option.value} value={option.value} control={<Radio color="primary" />} label={option.label} />
+            ))}
+          </RadioGroup>
+        </FormControl>
+      </Paper>
+    </Container>
+  );
+};
+
+export default Settings;

--- a/src/containers/settings/index.js
+++ b/src/containers/settings/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Settings";

--- a/src/containers/topBar/TopBar.js
+++ b/src/containers/topBar/TopBar.js
@@ -208,6 +208,11 @@ export default function PrimarySearchAppBar() {
     setOpen((state) => !state);
   };
 
+  const handleVersionClick = () => {
+    handleClose();
+    history.push("/settings");
+  };
+
   useEffect(() => {
     if (open) {
       document.getElementById("app-main-content").style.display = " none";
@@ -288,7 +293,7 @@ export default function PrimarySearchAppBar() {
                 history.push("/playlist")
                 handleClose()
               }} button={true}> Playlist </MenuItem>
-              <MenuItem button={false}>v{version}</MenuItem>
+              <MenuItem onClick={handleVersionClick} button={true}>v{version}</MenuItem>
               <MenuItem onClick={() => {
                 handleClose();
                 dispatch(downloadAudioList());

--- a/src/contexts/PreferencesContext.js
+++ b/src/contexts/PreferencesContext.js
@@ -1,0 +1,125 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { createMuiTheme, ThemeProvider } from "@material-ui/core/styles";
+
+const preferenceStorageKey = "user_preferences";
+
+const defaultPreferences = {
+  colorScheme: "light",
+  language: "english",
+};
+
+const paletteByScheme = {
+  sepia: {
+    primary: "#b88953",
+    background: "#f4ecd8",
+    text: "#3e2c1b",
+  },
+  red: {
+    primary: "#c62828",
+    background: "#ffe8e8",
+    text: "#3b0d0d",
+  },
+  green: {
+    primary: "#2e7d32",
+    background: "#e9f5e9",
+    text: "#123018",
+  },
+  blue: {
+    primary: "#1565c0",
+    background: "#e8f1fb",
+    text: "#0a2c57",
+  },
+  dark: {
+    primary: "#179992",
+    background: "#121212",
+    text: "#f5f5f5",
+  },
+  light: {
+    primary: "#179992",
+    background: "#f5f5f5",
+    text: "#111111",
+  },
+};
+
+const PreferencesContext = createContext({
+  preferences: defaultPreferences,
+  setColorScheme: () => {},
+  setLanguage: () => {},
+});
+
+const readPreferences = () => {
+  const stored = localStorage.getItem(preferenceStorageKey);
+  if (!stored) return defaultPreferences;
+
+  try {
+    const parsed = JSON.parse(stored);
+    return {
+      ...defaultPreferences,
+      ...parsed,
+    };
+  } catch (error) {
+    return defaultPreferences;
+  }
+};
+
+const writePreferences = (preferences) => {
+  localStorage.setItem(preferenceStorageKey, JSON.stringify(preferences));
+};
+
+export const usePreferences = () => useContext(PreferencesContext);
+
+const PreferencesProvider = ({ children }) => {
+  const [preferences, setPreferences] = useState(() => readPreferences());
+
+  useEffect(() => {
+    writePreferences(preferences);
+  }, [preferences]);
+
+  useEffect(() => {
+    const palette = paletteByScheme[preferences.colorScheme] || paletteByScheme.light;
+    document.body.style.backgroundColor = palette.background;
+    document.body.style.color = palette.text;
+    document.documentElement.setAttribute("data-color-scheme", preferences.colorScheme);
+  }, [preferences.colorScheme]);
+
+  useEffect(() => {
+    document.documentElement.setAttribute("lang", preferences.language);
+  }, [preferences.language]);
+
+  const setColorScheme = (scheme) => {
+    setPreferences((current) => ({ ...current, colorScheme: scheme }));
+  };
+
+  const setLanguage = (language) => {
+    setPreferences((current) => ({ ...current, language }));
+  };
+
+  const theme = useMemo(() => {
+    const palette = paletteByScheme[preferences.colorScheme] || paletteByScheme.light;
+    return createMuiTheme({
+      typography: {
+        fontFamily: "Roboto, Arial",
+      },
+      palette: {
+        primary: {
+          main: palette.primary,
+        },
+        background: {
+          default: palette.background,
+          paper: preferences.colorScheme === "dark" ? "#1f1f1f" : "#ffffff",
+        },
+        text: {
+          primary: palette.text,
+        },
+      },
+    });
+  }, [preferences.colorScheme]);
+
+  return (
+    <PreferencesContext.Provider value={{ preferences, setColorScheme, setLanguage }}>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </PreferencesContext.Provider>
+  );
+};
+
+export default PreferencesProvider;


### PR DESCRIPTION
### **User description**
## Summary
- add a settings route that lets users choose from predefined color schemes and languages
- link the version menu item in the top bar to the new settings page
- persist selected preferences in local storage so they remain on reload

## Testing
- npm run build *(fails: ERR_OSSL_EVP_UNSUPPORTED with Node 22)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6936cadecd04832aaa1545051a0255c2)


___

### **PR Type**
Enhancement


___

### **Description**
- Add new settings page with color scheme and language preferences

- Implement local storage persistence for user preferences

- Link version menu item to settings page for easy access

- Create reusable settings component with radio button selections


___

### Diagram Walkthrough


```mermaid
flowchart LR
  App["App.js<br/>Routes"] -->|imports| Settings["Settings Component<br/>Preferences UI"]
  TopBar["TopBar.js<br/>Version Menu"] -->|navigates to| Settings
  Settings -->|reads/writes| Storage["localStorage<br/>user_preferences"]
  Settings -->|displays| ColorScheme["Color Schemes<br/>6 options"]
  Settings -->|displays| Languages["Languages<br/>4 options"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.js</strong><dd><code>Add settings route to application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/App.js

<ul><li>Import new <code>Settings</code> component from containers<br> <li> Add <code>/settings</code> route to application routing configuration<br> <li> Settings component rendered at exact path <code>/settings</code></ul>


</details>


  </td>
  <td><a href="https://github.com/islamwell/nqa-1/pull/16/files#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Settings.js</strong><dd><code>Create settings component with preferences management</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/containers/settings/Settings.js

<ul><li>Create new Settings component with preferences UI using Material-UI <br>components<br> <li> Define color schemes (sepia, red, green, blue, dark, light) and <br>languages (French, Urdu, Norsk, English)<br> <li> Implement <code>readPreferences()</code> and <code>writePreferences()</code> functions for <br>localStorage management<br> <li> Use React hooks to manage colorScheme and language state with <br>automatic persistence via useEffect<br> <li> Render radio button groups for both color scheme and language <br>selection with dividers</ul>


</details>


  </td>
  <td><a href="https://github.com/islamwell/nqa-1/pull/16/files#diff-10d933dfae639e64639deff9564fb643d6696eab22113abf7e998b79e2c2ec41">+91/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Add settings component export barrel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/containers/settings/index.js

<ul><li>Create barrel export file for Settings component<br> <li> Enable clean import path from containers/settings</ul>


</details>


  </td>
  <td><a href="https://github.com/islamwell/nqa-1/pull/16/files#diff-f0c7a021677766a5a64e8fe5fdd6cdc77cfdbfec1e8620aeda037f9ee85b62fc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TopBar.js</strong><dd><code>Link version menu item to settings page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/containers/topBar/TopBar.js

<ul><li>Add <code>handleVersionClick()</code> function to navigate to settings page and <br>close menu<br> <li> Change version menu item from non-clickable to clickable with onClick <br>handler<br> <li> Version menu item now routes to <code>/settings</code> instead of displaying static <br>text</ul>


</details>


  </td>
  <td><a href="https://github.com/islamwell/nqa-1/pull/16/files#diff-7078865bb4fefdf8ceaa9011ed05028ee87d079287a5f7243effb6b55f074d9e">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

